### PR TITLE
Configure new components generation using generate-react-cli

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,10 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: [
+    "../src/lib/**/*.mdx",
+    "../src/lib/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/gen/templates/component/TemplateName.stories.tsx
+++ b/gen/templates/component/TemplateName.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TemplateName } from "./TemplateName";
+
+const meta = {
+  title: "Base/TemplateName",
+  component: TemplateName,
+  parameters: {
+    layout: "centered",
+  },
+  args: {},
+  argTypes: {},
+  tags: ["autodocs"],
+} satisfies Meta<typeof TemplateName>;
+
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {
+  args: {},
+};
+
+export default meta;

--- a/gen/templates/component/TemplateName.test.tsx
+++ b/gen/templates/component/TemplateName.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@/tests";
+import { TemplateName } from "./TemplateName";
+
+describe("TemplateName", () => {
+  test("Should render", () => {
+    render(<TemplateName>Template</TemplateName>);
+  });
+});

--- a/gen/templates/component/TemplateName.tsx
+++ b/gen/templates/component/TemplateName.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+
+interface TemplateNameProps {
+  prop?: string;
+}
+
+export function TemplateName({ prop }: PropsWithChildren<TemplateNameProps>) {
+  return <div>TEMPLATE COMPONENT {prop}</div>;
+}

--- a/gen/templates/component/index.ts
+++ b/gen/templates/component/index.ts
@@ -1,0 +1,1 @@
+export * from "./TemplateName";

--- a/generate-react-cli.json
+++ b/generate-react-cli.json
@@ -1,0 +1,23 @@
+{
+  "usesTypeScript": true,
+  "usesStyledComponents": false,
+  "usesCssModule": false,
+  "cssPreprocessor": "css",
+  "testLibrary": "Testing Library",
+  "component": {
+    "default": {
+      "path": "src/lib/components",
+      "withStyle": false,
+      "withTest": true,
+      "withStory": true,
+      "withIndex": true,
+      "withLazy": false,
+      "customTemplates": {
+        "component": "gen/templates/component/TemplateName.tsx",
+        "story": "gen/templates/component/TemplateName.stories.tsx",
+        "test": "gen/templates/component/TemplateName.test.tsx",
+        "index": "gen/templates/component/index.ts"
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "gen"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       formats: ["cjs", "es", "iife", "umd"],
     },
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: ["react", "react-dom", "./gen/*"],
       output: {
         globals: {
           react: "React",
@@ -36,6 +36,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/tests/setup.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Related to #68

# Changes:
- Setup [`generate-react-cli`](https://github.com/arminbro/generate-react-cli#readme) config.
  - It creates the following file in `src/lib/components/Name`:
    - `index.ts`
    - `Name.tsx`
    - `Name.test.tsx`
    - `Name.stories.tsx`
- Add custom templates in `gen/templates/component` folder.

# Notes:
## Usage: 
In your terminal run `npx generate-react-cli component YourComponentName`. It will create a component's folder with files in `src/lib/components` folder. 
### Demo:
[Screencast from 2024-03-29 23-48-42.webm](https://github.com/EXO-UI/exo-ui/assets/38109617/c64907e3-2569-4a4c-9d01-214d7c2db501)


